### PR TITLE
Making thread blockage on `subscribe` configurable

### DIFF
--- a/test/com/moclojer/rq/pubsub_test.clj
+++ b/test/com/moclojer/rq/pubsub_test.clj
@@ -14,7 +14,8 @@
      :msgs messages
      :workers (map (fn [[chan msg]]
                      {:channel chan
-                      :handler #(swap! state conj msg)})
+                      :handler (fn [_]
+                                 (swap! state conj msg))})
                    chans-msgs)}))
 
 (t/deftest pubsub-test


### PR DESCRIPTION
closes https://github.com/moclojer/clj-rq/issues/8

- **feat: make thread block configurable**
- **fix(test): recognize msg param on handler fn**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `blocking?` option to control thread blocking behavior during subscription.
  - Enhanced subscription logic to improve reconnection handling in case of connection issues.

- **Bug Fixes**
  - Improved the robustness of state updates in test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->